### PR TITLE
removed chars that create invalid filename and cause crash

### DIFF
--- a/entities/Util.ts
+++ b/entities/Util.ts
@@ -212,15 +212,15 @@ export class Util {
             try {
                 const downloadObj = await this.api.getV2(`/tracks/${track.id}/download`) as any
                 const result = await request(downloadObj.redirectUri)
-                dest = path.extname(dest) ? dest : path.join(dest, `${track.title.replace(/\//g, "")}.${result.headers["x-amz-meta-file-type"]}`)
+                dest = path.extname(dest) ? dest : path.join(dest, `${track.title.replace(/[\\/:*?\"<>|]/g, "")}.${result.headers["x-amz-meta-file-type"]}`)
                 const arrayBuffer = await result.body.arrayBuffer() as any
                 fs.writeFileSync(dest, Buffer.from(arrayBuffer, "binary"))
                 return dest
             } catch {
-                return this.downloadTrackStream(track, track.title.replace(/\//g, ""), dest)
+                return this.downloadTrackStream(track, track.title.replace(/[\\/:*?\"<>|]/g, ""), dest)
             }
         } else {
-            return this.downloadTrackStream(track, track.title.replace(/\//g, ""), dest)
+            return this.downloadTrackStream(track, track.title.replace(/[\\/:*?\"<>|]/g, ""), dest)
         }
     }
 
@@ -284,7 +284,7 @@ export class Util {
         if (!fs.existsSync(folder)) fs.mkdirSync(folder, {recursive: true})
         const track = await this.resolveTrack(trackResolvable)
         const artwork = (track.artwork_url ? track.artwork_url : track.user.avatar_url).replace(".jpg", ".png").replace("-large", "-t500x500")
-        const title = track.title.replace(/\//g, "")
+        const title = track.title.replace(/[\\/:*?\"<>|]/g, "")
         dest = path.extname(dest) ? dest : path.join(folder, `${title}.png`)
         const client_id = await this.api.getClientId()
         const url = `${artwork}?client_id=${client_id}`


### PR DESCRIPTION
I was running into crashes with `await soundcloud.util.downloadTrack(track,downloadsDirectory)` whenever the track title had quotes or other weird chars. So this pr is to remove any invalid characters from track.title to prevent crashes from invalid filenames